### PR TITLE
feat: PP-41-implement-semantic-release - added GitHub release workfow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+on:
+  push:
+    branches: [master]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v2
+        id: semantic
+        with:
+          semantic_version: 16
+          extra_plugins: |
+            @semantic-release/changelog
+            @semantic-release/git
+            conventional-changelog-eslint
+          branches: |
+            ['master']
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,86 @@
+{
+    "branch": "master",
+    "plugins": [
+        [
+            "@semantic-release/commit-analyzer",
+            {
+                "preset": "eslint",
+                "releaseRules": [
+                    {
+                        "tag": "major",
+                        "release": "major"
+                    },
+                    {
+                        "tag": "fix",
+                        "release": "patch"
+                    },
+                    {
+                        "tag": "minor",
+                        "release": "minor"
+                    },
+                    {
+                        "tag": "update",
+                        "release": "minor"
+                    },
+                    {
+                        "tag": "upgrade",
+                        "release": "minor"
+                    },
+                    {
+                        "tag": "feat",
+                        "release": "minor"
+                    }
+                ]
+            }
+        ],
+        [
+            "@semantic-release/release-notes-generator",
+            {
+                "preset": "eslint",
+                "releaseRules": [
+                    {
+                        "tag": "major",
+                        "release": "major"
+                    },
+                    {
+                        "tag": "fix",
+                        "release": "patch"
+                    },
+                    {
+                        "tag": "minor",
+                        "release": "minor"
+                    },
+                    {
+                        "tag": "update",
+                        "release": "minor"
+                    },
+                    {
+                        "tag": "upgrade",
+                        "release": "minor"
+                    },
+                    {
+                        "tag": "feat",
+                        "release": "minor"
+                    }
+                ]
+            }
+        ],
+        [
+            "@semantic-release/changelog",
+            {
+                "changelogFile": "CHANGELOG.md"
+            }
+        ],
+        "@semantic-release/github",
+        [
+            "@semantic-release/git",
+            {
+                "assets": [
+                    "package.json",
+                    "CHANGELOG.md"
+                ],
+                "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+            }
+        ]
+    ]
+}


### PR DESCRIPTION
#  PP-41-implement-semantic-release
- [x] Release type: feature
- [x] Description: added the semantic release configuration file & defined the CI/CD workflow process
- [x] Impact severity: low
- [x] Impact assessment: no impact due to new repository   